### PR TITLE
Fixes #6: Correct the radio input name attribute in a11y documentation

### DIFF
--- a/content/components/control-input/accessibility/example-code.md
+++ b/content/components/control-input/accessibility/example-code.md
@@ -14,7 +14,7 @@
     <label class="au-control-input__text" for="radio-phone">Phone</label>
   </div>
   <div class="au-control-input">
-    <input class="au-control-input__input" type="radio" name="radio-ex-dark" id="radio-tablet" checked>
+    <input class="au-control-input__input" type="radio" name="radio-ex" id="radio-tablet" checked>
     <label class="au-control-input__text" for="radio-tablet">Tablet</label>
   </div>
 </p>

--- a/content/components/control-input/accessibility/example-dark.md
+++ b/content/components/control-input/accessibility/example-dark.md
@@ -10,7 +10,7 @@
 </div>
 <p>
   <div class="au-control-input au-control-input--dark">
-    <input class="au-control-input__input" type="radio" name="radio-ex" id="radio-phone-dark">
+    <input class="au-control-input__input" type="radio" name="radio-ex-dark" id="radio-phone-dark">
     <label class="au-control-input__text" for="radio-phone-dark">Phone</label>
   </div>
   <div class="au-control-input au-control-input--dark">


### PR DESCRIPTION
Correct the radio input name attribute in a11y documentation

This was breaking the accessibility examples and causing incorrect tab behaviour and screen reader output.