### PR TITLE
Page alerts: Update accessibility code example

### DIFF
--- a/content/components/page-alerts/accessibility/example-dark.md
+++ b/content/components/page-alerts/accessibility/example-dark.md
@@ -1,20 +1,20 @@
 <div class="au-body au-body--dark">
-  <div class="au-page-alerts au-page-alerts--info">
+  <div class="au-page-alerts au-page-alerts--info au-page-alerts--dark">
     <h3>Important</h3>
     <p>Alert Content <a href="#">link</a></p>
   </div>
 
-  <div class="au-page-alerts au-page-alerts--success">
+  <div class="au-page-alerts au-page-alerts--success au-page-alerts--dark">
     <h3>Success</h3>
     <p>Alert Content <a href="#">link</a></p>
   </div>
 
-  <div class="au-page-alerts au-page-alerts--error">
+  <div class="au-page-alerts au-page-alerts--error au-page-alerts--dark">
     <h3>Error</h3>
     <p>Alert Content <a href="#">link</a></p>
   </div>
 
-  <div class="au-page-alerts au-page-alerts--warning">
+  <div class="au-page-alerts au-page-alerts--warning au-page-alerts--dark">
     <h3>Warning</h3>
     <p>Alert content <a href="#">link</a></p>
   </div>

--- a/content/components/page-alerts/success.md
+++ b/content/components/page-alerts/success.md
@@ -7,7 +7,7 @@ code:
       <!--
         Light:      <div class="au-page-alerts au-page-alerts--success">
         Light Alt:  <div class="au-page-alerts au-page-alerts--success au-page-alerts--alt">
-        Dark:       <div class="au-body au-body--dark au-page-alerts au-page-alerts--success au-page-alerts--dark >
+        Dark:       <div class="au-body au-body--dark au-page-alerts au-page-alerts--success au-page-alerts--dark">
         Dark Alt:   <div class="au-body au-body--dark au-body--alt au-page-alerts au-page-alerts--success au-page-alerts--dark au-page-alerts--alt">
       -->
 


### PR DESCRIPTION
In the [Accessibility tab](https://gold.designsystemau.org/components/page-alerts/accessibility/) for the "Page alerts" component, the dark examples are missing the class `au-page-alerts--dark`. 

This means that the icons have an incorrect background colour and differ from the dark examples on the [Overview tab](https://gold.designsystemau.org/components/page-alerts/#info).

### Screenshots

| Before      | After |
| ----------- | ----------- |
| <img width="905" alt="Screen Shot 2022-02-15 at 8 52 52 pm" src="https://user-images.githubusercontent.com/6265154/154048535-1175a1c9-b072-4065-92c2-142e5270698f.png">      | <img width="905" alt="Screen Shot 2022-02-15 at 8 54 08 pm" src="https://user-images.githubusercontent.com/6265154/154048549-046461f6-6e35-4636-bcad-ef3c8335799c.png">       |




