### PR TITLE
Update documentation for Progress Indicator

### DIFF
--- a/content/components/progress-indicator/default.md
+++ b/content/components/progress-indicator/default.md
@@ -55,13 +55,13 @@ code:
         },
       ]} />
 ---
+
 ## Default
 
 Our design system provides a progress indicator for larger tasks that can be completed out of order and returned to at a later date, like doing a tax return or applying for a driver’s licence.
 
 The individual tasks or steps are shown as either:
 
-- `open` – the task is available for the user to do
-- `partly finished` – the task has been started
-- `finished` – the task has been completed
-- `not yet started` – the user has to do something before the task can be started.
+- `todo` – the task is available for the user to do
+- `doing` – the task has been started
+- `done` – the task has been completed


### PR DESCRIPTION
In the documentation for [Progress Indicator](https://gold.designsystemau.org/components/progress-indicator/) it states that each step can be in 1 of 4 possible states (`open`, `partly finished`, `finished` and `not yet started`),

But it appears there are only 3 states  which are `todo`, `doing` and `done`. These states are available via these classes:

- `au-progress-indicator__link--todo`
- `au-progress-indicator__link--doing`
-  `au-progress-indicator__link--done`

This PR updates the documentation for this component to reflect this.